### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/2](https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/2)

To fix this problem, add a `permissions` block to the workflow file (.github/workflows/build.yml) at the top level (before or after `on:` but outside `jobs:`). This will apply restrictive permissions (e.g., `contents: read`) to all jobs defined in the workflow, unless overridden per job. This prevents the default token from having excessive permissions and follows best practices. The block to add is:

```yaml
permissions:
  contents: read
```

No other changes, imports, or added logic are needed elsewhere in the file, since none of the jobs’ steps (including checkouts/builds) require further access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
