### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,6 @@
 name: Shellcheck CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/3](https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/3)

To fix the problem, we need to explicitly set the `permissions` key to restrict the GITHUB_TOKEN's access for this workflow. Since the job only checks out the repository and runs shellcheck (a static analysis tool) on shell scripts, it only needs minimal read access to the repository contents. The best fix is to add `permissions: contents: read` either at the top/root level of the workflow or within the `shellcheck` job block. To cover all jobs (present and potential future ones), it's preferable to define it at the root level, just under the workflow `name` and before the `on` block. This minimizes the privileges for the workflow and adheres to the principle of least privilege.

Changes needed:
- Add the following block right after `name: Shellcheck CI`:
  ```yaml
  permissions:
    contents: read
  ```

No other imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
