### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-link.yml
+++ b/.github/workflows/markdown-link.yml
@@ -1,4 +1,6 @@
 name: Markdown link CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/4](https://github.com/26zl/Realtek-8821au-driver-with-monitor-mode/security/code-scanning/4)

To fix the problem, we need to add a `permissions` block that grants the minimum necessary privileges for the job. Since neither `actions/checkout` nor the markdown link check action require write access to the repository, the least privilege is `contents: read`. Add this block either at the top-level (applying to all jobs) or at the job-level (just for `markdown-link-check`). The most straightforward and maintainable option is to add `permissions: contents: read` at the workflow level, right below the `name:` and above the `on:` key in `.github/workflows/markdown-link.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
