### PR TITLE
Potential fix for code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -861,21 +861,21 @@ void *rtw_malloc2d(int h, int w, size_t size)
 {
 	int j;
 
-	void **a = (void **) rtw_zmalloc(h * sizeof(void *) + h * w * size);
+	void **a = (void **) rtw_zmalloc((size_t)h * sizeof(void *) + (size_t)h * (size_t)w * size);
 	if (a == NULL) {
 		RTW_INFO("%s: alloc memory fail!\n", __FUNCTION__);
 		return NULL;
 	}
 
 	for (j = 0; j < h; j++)
-		a[j] = ((char *)(a + h)) + j * w * size;
+		a[j] = ((char *)(a + h)) + (size_t)j * (size_t)w * size;
 
 	return a;
 }
 
 void rtw_mfree2d(void *pbuf, int h, int w, int size)
 {
-	rtw_mfree((u8 *)pbuf, h * sizeof(void *) + w * h * size);
+	rtw_mfree((u8 *)pbuf, (size_t)h * sizeof(void *) + (size_t)w * (size_t)h * (size_t)size);
 }
 
 inline void rtw_os_pkt_free(_pkt *pkt)


### PR DESCRIPTION
Potential fix for [https://github.com/26zl/Realtek8821au-Linux-Driver-Monitor-Mode/security/code-scanning/7](https://github.com/26zl/Realtek8821au-Linux-Driver-Monitor-Mode/security/code-scanning/7)

The correct fix is to ensure all size/offset multiplications are carried out in a sufficiently wide unsigned type (`size_t`) from the first multiplication operand onward.  
Best single approach without changing functionality:

- In `os_dep/osdep_service.c`, function `rtw_malloc2d`:
  - Change allocation-size expression so both terms are computed in `size_t`:
    - `(size_t)h * sizeof(void *)`
    - `(size_t)h * (size_t)w * size`
  - Change row offset expression to compute using `size_t`:
    - `(size_t)j * (size_t)w * size`
- In `rtw_mfree2d`, similarly compute total free size in `size_t`:
  - `(size_t)h * sizeof(void *) + (size_t)w * (size_t)h * (size_t)size`

No new imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
